### PR TITLE
Merge upstream v1.10.6

### DIFF
--- a/cmd/evm/testdata/12/alloc.json
+++ b/cmd/evm/testdata/12/alloc.json
@@ -1,0 +1,11 @@
+{
+    "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+        "balance" : "84000000",
+        "code" : "0x",
+        "nonce" : "0x00",
+        "storage" : {
+            "0x00" : "0x00"
+        }
+    }
+}
+

--- a/cmd/evm/testdata/12/env.json
+++ b/cmd/evm/testdata/12/env.json
@@ -1,0 +1,10 @@
+{
+    "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+    "currentDifficulty" : "0x020000",
+    "currentNumber" : "0x01",
+    "currentTimestamp" : "0x03e8",
+    "previousHash" : "0xfda4419b3660e99f37e536dae1ab081c180136bb38c837a93e93d9aab58553b2",
+    "currentGasLimit" : "0x0f4240",
+    "currentBaseFee" : "0x20"
+}
+

--- a/cmd/evm/testdata/12/readme.md
+++ b/cmd/evm/testdata/12/readme.md
@@ -1,0 +1,40 @@
+## Test 1559 balance + gasCap
+
+This test contains an EIP-1559 consensus issue which happened on Ropsten, where
+`geth` did not properly account for the value transfer while doing the check on `max_fee_per_gas * gas_limit`.
+
+Before the issue was fixed, this invocation allowed the transaction to pass into a block:
+```
+dir=./testdata/12 && ./evm t8n --state.fork=London --input.alloc=$dir/alloc.json --input.txs=$dir/txs.json --input.env=$dir/env.json --output.alloc=stdout --output.result=stdout
+```
+
+With the fix applied, the result is: 
+```
+dir=./testdata/12 && ./evm t8n --state.fork=London --input.alloc=$dir/alloc.json --input.txs=$dir/txs.json --input.env=$dir/env.json --output.alloc=stdout --output.result=stdout
+INFO [07-21|19:03:50.276] rejected tx                              index=0 hash=ccc996..d83435 from=0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B error="insufficient funds for gas * price + value: address 0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B have 84000000 want 84000032"
+INFO [07-21|19:03:50.276] Trie dumping started                     root=e05f81..6597a5
+INFO [07-21|19:03:50.276] Trie dumping complete                    accounts=1 elapsed="39.549µs"
+{
+ "alloc": {
+  "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b": {
+   "balance": "0x501bd00"
+  }
+ },
+ "result": {
+  "stateRoot": "0xe05f81f8244a76503ceec6f88abfcd03047a612a1001217f37d30984536597a5",
+  "txRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+  "receiptRoot": "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+  "logsHash": "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+  "logsBloom": "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+  "receipts": [],
+  "rejected": [
+   {
+    "index": 0,
+    "error": "insufficient funds for gas * price + value: address 0xa94f5374Fce5edBC8E2a8697C15331677e6EbF0B have 84000000 want 84000032"
+   }
+  ]
+ }
+}
+```
+
+The transaction is rejected. 

--- a/cmd/evm/testdata/12/txs.json
+++ b/cmd/evm/testdata/12/txs.json
@@ -1,0 +1,20 @@
+[
+    {
+        "input" : "0x",
+        "gas" : "0x5208",
+        "nonce" : "0x0",
+        "to" : "0x1111111111111111111111111111111111111111",
+        "value" : "0x20",
+        "v" : "0x0",
+        "r" : "0x0",
+        "s" : "0x0",
+        "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+        "chainId" : "0x1",
+        "type" : "0x2",
+        "maxFeePerGas" : "0xfa0",
+        "maxPriorityFeePerGas" : "0x20",
+        "accessList" : [
+        ]
+    }
+]
+

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -118,7 +118,7 @@ func TestStateProcessorErrors(t *testing.T) {
 				txs: []*types.Transaction{
 					makeTx(0, common.Address{}, big.NewInt(1000000000000000000), params.TxGas, big.NewInt(875000000), nil),
 				},
-				want: "could not apply tx 0 [0x98c796b470f7fcab40aaef5c965a602b0238e1034cce6fb73823042dd0638d74]: insufficient funds for transfer: address 0x71562b71999873DB5b286dF957af199Ec94617F7",
+				want: "could not apply tx 0 [0x98c796b470f7fcab40aaef5c965a602b0238e1034cce6fb73823042dd0638d74]: insufficient funds for gas * price + value: address 0x71562b71999873DB5b286dF957af199Ec94617F7 have 1000000000000000000 want 1000018375000000000",
 			},
 			{ // ErrInsufficientFunds
 				txs: []*types.Transaction{

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -193,6 +193,7 @@ func (st *StateTransition) buyGas() error {
 	if st.gasFeeCap != nil {
 		balanceCheck = new(big.Int).SetUint64(st.msg.Gas())
 		balanceCheck = balanceCheck.Mul(balanceCheck, st.gasFeeCap)
+		balanceCheck.Add(balanceCheck, st.value)
 	}
 	if have, want := st.state.GetBalance(st.msg.From()), balanceCheck; have.Cmp(want) < 0 {
 		return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From().Hex(), have, want)

--- a/core/types/gen_log_json.go
+++ b/core/types/gen_log_json.go
@@ -18,12 +18,12 @@ func (l Log) MarshalJSON() ([]byte, error) {
 		Address     common.Address `json:"address" gencodec:"required"`
 		Topics      []common.Hash  `json:"topics" gencodec:"required"`
 		Data        hexutil.Bytes  `json:"data" gencodec:"required"`
-		BlockNumber hexutil.Uint64 `json:"blockNumber" rlp:"-"`
-		TxHash      common.Hash    `json:"transactionHash" gencodec:"required" rlp:"-"`
-		TxIndex     hexutil.Uint   `json:"transactionIndex" rlp:"-"`
-		BlockHash   common.Hash    `json:"blockHash" rlp:"-"`
-		Index       hexutil.Uint   `json:"logIndex" rlp:"-"`
-		Removed     bool           `json:"removed" rlp:"-"`
+		BlockNumber hexutil.Uint64 `json:"blockNumber"`
+		TxHash      common.Hash    `json:"transactionHash" gencodec:"required"`
+		TxIndex     hexutil.Uint   `json:"transactionIndex"`
+		BlockHash   common.Hash    `json:"blockHash"`
+		Index       hexutil.Uint   `json:"logIndex"`
+		Removed     bool           `json:"removed"`
 	}
 	var enc Log
 	enc.Address = l.Address
@@ -44,12 +44,12 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 		Address     *common.Address `json:"address" gencodec:"required"`
 		Topics      []common.Hash   `json:"topics" gencodec:"required"`
 		Data        *hexutil.Bytes  `json:"data" gencodec:"required"`
-		BlockNumber *hexutil.Uint64 `json:"blockNumber" rlp:"-"`
-		TxHash      *common.Hash    `json:"transactionHash" gencodec:"required" rlp:"-"`
-		TxIndex     *hexutil.Uint   `json:"transactionIndex" rlp:"-"`
-		BlockHash   *common.Hash    `json:"blockHash" rlp:"-"`
-		Index       *hexutil.Uint   `json:"logIndex" rlp:"-"`
-		Removed     *bool           `json:"removed" rlp:"-"`
+		BlockNumber *hexutil.Uint64 `json:"blockNumber"`
+		TxHash      *common.Hash    `json:"transactionHash" gencodec:"required"`
+		TxIndex     *hexutil.Uint   `json:"transactionIndex"`
+		BlockHash   *common.Hash    `json:"blockHash"`
+		Index       *hexutil.Uint   `json:"logIndex"`
+		Removed     *bool           `json:"removed"`
 	}
 	var dec Log
 	if err := json.Unmarshal(input, &dec); err != nil {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -94,7 +94,28 @@ type receiptRLP struct {
 type storedReceiptRLP struct {
 	PostStateOrStatus []byte
 	CumulativeGasUsed uint64
-	Logs              []*Log
+	Logs              []*LogForStorage
+}
+
+// v4StoredReceiptRLP is the storage encoding of a receipt used in database version 4.
+type v4StoredReceiptRLP struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	TxHash            common.Hash
+	ContractAddress   common.Address
+	Logs              []*LogForStorage
+	GasUsed           uint64
+}
+
+// v3StoredReceiptRLP is the original storage encoding of a receipt including some unnecessary fields.
+type v3StoredReceiptRLP struct {
+	PostStateOrStatus []byte
+	CumulativeGasUsed uint64
+	Bloom             Bloom
+	TxHash            common.Hash
+	ContractAddress   common.Address
+	Logs              []*LogForStorage
+	GasUsed           uint64
 }
 
 // NewReceipt creates a barebone transaction receipt, copying the init fields.
@@ -212,28 +233,96 @@ func (r *Receipt) Size() common.StorageSize {
 // entire content of a receipt, as opposed to only the consensus fields originally.
 type ReceiptForStorage Receipt
 
-// EncodeRLP implements rlp.Encoder.
+// EncodeRLP implements rlp.Encoder, and flattens all content fields of a receipt
+// into an RLP stream.
 func (r *ReceiptForStorage) EncodeRLP(w io.Writer) error {
 	enc := &storedReceiptRLP{
 		PostStateOrStatus: (*Receipt)(r).statusEncoding(),
 		CumulativeGasUsed: r.CumulativeGasUsed,
-		Logs:              r.Logs,
+		Logs:              make([]*LogForStorage, len(r.Logs)),
+	}
+	for i, log := range r.Logs {
+		enc.Logs[i] = (*LogForStorage)(log)
 	}
 	return rlp.Encode(w, enc)
 }
 
-// DecodeRLP implements rlp.Decoder.
+// DecodeRLP implements rlp.Decoder, and loads both consensus and implementation
+// fields of a receipt from an RLP stream.
 func (r *ReceiptForStorage) DecodeRLP(s *rlp.Stream) error {
+	// Retrieve the entire receipt blob as we need to try multiple decoders
+	blob, err := s.Raw()
+	if err != nil {
+		return err
+	}
+	// Try decoding from the newest format for future proofness, then the older one
+	// for old nodes that just upgraded. V4 was an intermediate unreleased format so
+	// we do need to decode it, but it's not common (try last).
+	if err := decodeStoredReceiptRLP(r, blob); err == nil {
+		return nil
+	}
+	if err := decodeV3StoredReceiptRLP(r, blob); err == nil {
+		return nil
+	}
+	return decodeV4StoredReceiptRLP(r, blob)
+}
+
+func decodeStoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
 	var stored storedReceiptRLP
-	if err := s.Decode(&stored); err != nil {
+	if err := rlp.DecodeBytes(blob, &stored); err != nil {
 		return err
 	}
 	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
 		return err
 	}
 	r.CumulativeGasUsed = stored.CumulativeGasUsed
-	r.Logs = stored.Logs
+	r.Logs = make([]*Log, len(stored.Logs))
+	for i, log := range stored.Logs {
+		r.Logs[i] = (*Log)(log)
+	}
 	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
+
+	return nil
+}
+
+func decodeV4StoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
+	var stored v4StoredReceiptRLP
+	if err := rlp.DecodeBytes(blob, &stored); err != nil {
+		return err
+	}
+	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
+		return err
+	}
+	r.CumulativeGasUsed = stored.CumulativeGasUsed
+	r.TxHash = stored.TxHash
+	r.ContractAddress = stored.ContractAddress
+	r.GasUsed = stored.GasUsed
+	r.Logs = make([]*Log, len(stored.Logs))
+	for i, log := range stored.Logs {
+		r.Logs[i] = (*Log)(log)
+	}
+	r.Bloom = CreateBloom(Receipts{(*Receipt)(r)})
+
+	return nil
+}
+
+func decodeV3StoredReceiptRLP(r *ReceiptForStorage, blob []byte) error {
+	var stored v3StoredReceiptRLP
+	if err := rlp.DecodeBytes(blob, &stored); err != nil {
+		return err
+	}
+	if err := (*Receipt)(r).setStatus(stored.PostStateOrStatus); err != nil {
+		return err
+	}
+	r.CumulativeGasUsed = stored.CumulativeGasUsed
+	r.Bloom = stored.Bloom
+	r.TxHash = stored.TxHash
+	r.ContractAddress = stored.ContractAddress
+	r.GasUsed = stored.GasUsed
+	r.Logs = make([]*Log, len(stored.Logs))
+	for i, log := range stored.Logs {
+		r.Logs[i] = (*Log)(log)
+	}
 	return nil
 }
 

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -369,7 +369,7 @@ func TestOverriddenTraceCall(t *testing.T) {
 			config: &TraceCallConfig{
 				Tracer: &tracer,
 			},
-			expectErr: core.ErrInsufficientFundsForTransfer,
+			expectErr: core.ErrInsufficientFunds,
 			expect:    nil,
 		},
 		// Successful simple contract call

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -306,7 +306,7 @@ func TestTraceCall(t *testing.T) {
 	}
 }
 
-func TestOverridenTraceCall(t *testing.T) {
+func TestOverriddenTraceCall(t *testing.T) {
 	t.Parallel()
 
 	// Initialize test accounts

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -60,8 +60,11 @@ func (b *LesApiBackend) SetHead(number uint64) {
 }
 
 func (b *LesApiBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*types.Header, error) {
+	// Return the latest current as the pending one since there
+	// is no pending notion in the light client. TODO(rjl493456442)
+	// unify the behavior of `HeaderByNumber` and `PendingBlockAndReceipts`.
 	if number == rpc.PendingBlockNumber {
-		return nil, nil
+		return b.eth.blockchain.CurrentHeader(), nil
 	}
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentHeader(), nil

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -251,7 +251,7 @@ func (h *httpServer) doStop() {
 
 	// Shut down the server.
 	httpHandler := h.httpHandler.Load().(*rpcHandler)
-	wsHandler := h.httpHandler.Load().(*rpcHandler)
+	wsHandler := h.wsHandler.Load().(*rpcHandler)
 	if httpHandler != nil {
 		h.httpHandler.Store((*rpcHandler)(nil))
 		httpHandler.server.Stop()

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1        // Major version component of the current release
-	VersionMinor = 10       // Minor version component of the current release
-	VersionPatch = 5        // Patch version component of the current release
-	VersionMeta  = "stable" // Version metadata to append to the version string
+	VersionMajor = 1          // Major version component of the current release
+	VersionMinor = 10         // Minor version component of the current release
+	VersionPatch = 6          // Patch version component of the current release
+	VersionMeta  = "unstable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.

--- a/params/version.go
+++ b/params/version.go
@@ -21,10 +21,10 @@ import (
 )
 
 const (
-	VersionMajor = 1          // Major version component of the current release
-	VersionMinor = 10         // Minor version component of the current release
-	VersionPatch = 6          // Patch version component of the current release
-	VersionMeta  = "unstable" // Version metadata to append to the version string
+	VersionMajor = 1        // Major version component of the current release
+	VersionMinor = 10       // Minor version component of the current release
+	VersionPatch = 6        // Patch version component of the current release
+	VersionMeta  = "stable" // Version metadata to append to the version string
 )
 
 // Version holds the textual version string.


### PR DESCRIPTION
Merge all commits from go-Ethereum v1.10.6 into develop. 

Diff stats between upstream v1.10.6 and head of this pull request: 

```diff

 .github/dependabot.yml                   |   11 +
 .github/workflows/codeql.yml             |   76 +
 .github/workflows/hive.yml               |   41 +
 .github/workflows_old/docker-image.yml   |   55 +
 .gitignore                               |    2 +
 Dockerfile                               |    2 +
 KCC_Green.png                            |  Bin 0 -> 88361 bytes
 README.md                                |  255 +--
 accounts/accounts.go                     |    1 +
 accounts/external/backend.go             |    6 +-
 cmd/clef/main.go                         |    2 +-
 cmd/devp2p/discv4cmd.go                  |    2 +-
 cmd/devp2p/nodesetcmd.go                 |    8 +-
 cmd/geth/chaincmd.go                     |    5 +-
 cmd/geth/config.go                       |    1 +
 cmd/geth/consolecmd.go                   |   20 +-
 cmd/geth/dbcmd.go                        |   40 +-
 cmd/geth/main.go                         |   22 +-
 cmd/geth/snapshot.go                     |   23 +-
 cmd/geth/usage.go                        |    6 +-
 cmd/utils/flags.go                       |  111 +-
 consensus/clique/clique.go               |    4 +-
 consensus/consensus.go                   |    7 +-
 consensus/ethash/consensus.go            |    4 +-
 consensus/posa/abi.go                    | 2827 ++++++++++++++++++++++++++++++
 consensus/posa/api.go                    |  147 ++
 consensus/posa/interactive.go            |   86 +
 consensus/posa/kccIshikari.go            |  103 ++
 consensus/posa/kccIshikari_patch.go      |  105 ++
 consensus/posa/kccIshikari_patch_test.go |   24 +
 consensus/posa/posa.go                   | 1170 +++++++++++++
 consensus/posa/snapshot.go               |  203 +++
 core/forkid/forkid.go                    |    7 +
 core/forkid/forkid_test.go               |   68 -
 core/genesis.go                          |   77 +-
 core/genesis_alloc.go                    |    8 +-
 core/mkalloc.go                          |   10 +-
 core/rawdb/database.go                   |    4 +
 core/state_transition.go                 |   37 +-
 core/types/transaction.go                |    9 +-
 core/vm/analysis.go                      |   94 +-
 core/vm/analysis_test.go                 |   24 +-
 core/vm/instructions.go                  |    4 +
 core/vm/instructions_kcc_issue_9.go      |   62 +
 core/vm/interpreter.go                   |   17 +-
 core/vm/jump_table.go                    |   27 +-
 eth/backend.go                           |   59 +-
 eth/ethconfig/config.go                  |   14 +-
 eth/gasprice/gasprice.go                 |   16 +
 eth/protocols/eth/handler.go             |    2 +-
 genesis-mainnet.json                     |   47 +
 genesis-testnet.json                     |   50 +
 internal/ethapi/api.go                   |   19 +-
 internal/web3ext/web3ext.go              |   31 +
 les/commons.go                           |    2 +-
 les/protocol.go                          |    2 +-
 miner/miner.go                           |    8 +-
 miner/worker.go                          |    9 +
 mobile/geth.go                           |   24 +-
 mobile/params.go                         |   24 +-
 p2p/peer.go                              |    6 +-
 p2p/peer_error.go                        |    2 +-
 params/bootnodes.go                      |  103 +-
 params/config.go                         |  455 ++---
 params/version.go                        |    6 +-
 65 files changed, 5749 insertions(+), 947 deletions(-)


```