### PR TITLE
cmd/geth: fix legacy receipt detection for empty db (ethereum#25609)

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -175,12 +175,13 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 		if cfg.Eth.NetworkId == 1 && ghash == params.MainnetGenesisHash {
 			firstIdx = 46147
 		}
-		isLegacy, _, err := dbHasLegacyReceipts(eth.ChainDb(), firstIdx)
+		isLegacy, firstLegacy, err := dbHasLegacyReceipts(eth.ChainDb(), firstIdx)
 		if err != nil {
 			log.Error("Failed to check db for legacy receipts", "err", err)
 		} else if isLegacy {
 			stack.Close()
-			utils.Fatalf("Database has receipts with a legacy format. Please run `geth db freezer-migrate`.")
+			log.Error("Database has receipts with a legacy format", "firstLegacy", firstLegacy)
+			utils.Fatalf("Aborting. Please run `geth db freezer-migrate`.")
 		}
 	}
 

--- a/cmd/geth/dbcmd.go
+++ b/cmd/geth/dbcmd.go
@@ -822,11 +822,15 @@ func dbHasLegacyReceipts(db ethdb.Database, firstIdx uint64) (bool, uint64, erro
 			}
 		}
 	}
-	// Is first non-empty receipt legacy?
 	first, err := db.Ancient("receipts", firstIdx)
 	if err != nil {
 		return false, 0, err
 	}
+	// We looped over all receipts and they were all empty
+	if bytes.Equal(first, emptyRLPList) {
+		return false, 0, nil
+	}
+	// Is first non-empty receipt legacy?
 	legacy, err = types.IsLegacyStoredReceipts(first)
 	return legacy, firstIdx, err
 }


### PR DESCRIPTION
This is a bug introduced in v1.10.19 and fixed in v1.11.0.   
As we will not merge v1.11.X recently,  we can cherry-pick the fix.  


A hive simulator will be added for this bug: https://github.com/kcc-community/hive/issues/15 