### PR TITLE
utils, close #3 , fix  crash on importing blocks

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -35,6 +35,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/fdlimit"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/ethash"
+	"github.com/ethereum/go-ethereum/consensus/posa"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -2141,6 +2142,12 @@ func MakeChain(ctx *cli.Context, stack *node.Node) (chain *core.BlockChain, chai
 	if err != nil {
 		Fatalf("Can't create BlockChain: %v", err)
 	}
+
+	// set state fn if consensus engine is posa.
+	if posaEngine, ok := engine.(*posa.POSA); ok {
+		posaEngine.SetStateFn(chain.StateAt)
+	}
+
 	return chain, chainDb
 }
 


### PR DESCRIPTION
Fix #10 

- The `MakeChain` function has been heavily refactored since upstream v1.10.1 .  
- To fix `geth import`, we only need to set the state-fetching callback  

