### PR TITLE
disable "paris Engine" API

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -41,7 +41,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth"
-	ethcatalyst "github.com/ethereum/go-ethereum/eth/catalyst"
 	"github.com/ethereum/go-ethereum/eth/downloader"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/eth/filters"
@@ -1942,9 +1941,10 @@ func RegisterEthService(stack *node.Node, cfg *ethconfig.Config) (ethapi.Backend
 			Fatalf("Failed to create the LES server: %v", err)
 		}
 	}
-	if err := ethcatalyst.Register(stack, backend); err != nil {
-		Fatalf("Failed to register the Engine API service: %v", err)
-	}
+	// @KCC: Disable Engine API
+	// if err := ethcatalyst.Register(stack, backend); err != nil {
+	// 	Fatalf("Failed to register the Engine API service: %v", err)
+	// }
 	stack.RegisterAPIs(tracers.APIs(backend.APIBackend))
 	return backend.APIBackend, backend
 }


### PR DESCRIPTION
## What is `Engine API` 

`Engine API` is introduced in "The Merge". Since "the Merge",  `geth` works only as an "execution engine":  

- If the `Consensus Engine` wants to propose a new block, it will ask the `execution engine` to build a new one.  
- If the `Consensus Engine` receives a new block, it will ask the `execution engine` to insert the block and transit the state.  

The `consensus Engine` and `execution engine` communicates by the Engine API.  

<img width="477" alt="image" src="https://user-images.githubusercontent.com/95088118/222609216-d1162c96-33e3-4dc1-9628-c3f9cc1a34bb.png">


## Why should we disable `Engine API`  

Currently, we don't need such architecture which separates `consensus` and  `execution`.  And if we accidentally expose the  powerful `Engine API`,  that could possibly leave an attack vector.   