### PR TITLE
git actions, add more hive simulators

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -27,8 +27,24 @@ jobs:
         run: cd $GITHUB_WORKSPACE/kcc && docker build -t kucoincommunitychain/kcc:latest . 
       - name: build hive 
         run: cd $GITHUB_WORKSPACE/hive && go build -v . 
-      - name: run smoke simulator 
+      - name: "[hive] smoke test"
         run: |
             cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc_latest --sim 'kcc/(smoke|gas-block-limit)' \
-             ${{ inputs.hive_extra_flags }}
-
+             ${{ inputs.hive_extra_flags }} 
+      - name: "[hive] Pre EIP-1559"
+        run: |
+            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client.checktimelimit 10m --client kcc_latest --sim 'kcc/(ancient-db|auth-server|test-flag|deploy-contract|pre-1559|new-txpool)' \
+             ${{ inputs.hive_extra_flags }}  
+      - name: "[hive] Synchronization  with an old client"
+        run: |
+            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc,kcc_v1.2.0 --sim 'kcc/(devp2p-eth66)' \
+             ${{ inputs.hive_extra_flags }}  
+      - name: "[hive] issue-9, mallicious tx "
+        run: |
+            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc,kcc_v1.0.3 --sim 'kcc/issues/issue-9' \
+             ${{ inputs.hive_extra_flags }}  
+      - name: "[hive] Ishikari hardfork (without punishment)"
+        run: |
+            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc --sim 'kcc/ishikari-(distri|inactive|multinode|singlenode)' \
+             ${{ inputs.hive_extra_flags }}  
+      

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -29,7 +29,7 @@ jobs:
         run: cd $GITHUB_WORKSPACE/hive && go build -v . 
       - name: "[hive] smoke test"
         run: |
-            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc_latest --sim 'kcc/(smoke|gas-block-limit)' \
+            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc_latest --sim 'kcc/(smoke|gas-block-limit|gpo)' \
              ${{ inputs.hive_extra_flags }} 
       - name: "[hive] Pre EIP-1559"
         run: |


### PR DESCRIPTION
Add more hive simulators to GitHub actions.   

Note: It costs around 25m to run all the simulators.  