### PR TITLE
Add a new github action for creating releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,57 @@
+name: build-and-release
+run-name: "Build & Release"
+on: 
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: The branch to build 
+        required: false
+        default:  "kcc"
+        type: string 
+      docker_repo:
+        description: The docker hub repo 
+        required: false
+        default: "kucoincommunitychain/kcc"
+jobs:
+  build-and-release:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout kcc's repo into kcc/
+        uses: actions/checkout@v3
+        with:
+          path: kcc
+          ref: ${{ inputs.branch }}
+      - name: build kcc docker image 
+        run: cd $GITHUB_WORKSPACE/kcc && docker build -t ${{ inputs.docker_repo }}:latest . 
+      - name: copy binary 
+        run: |
+           mkdir -p $GITHUB_WORKSPACE/build/bin && docker create --name binContainer ${{ inputs.docker_repo }}:latest && \
+           docker cp binContainer:/usr/local/bin/geth $GITHUB_WORKSPACE/build/bin/geth && ls -la $GITHUB_WORKSPACE/build/bin/geth
+      - name: Get the version from the binary
+        run: |
+          version_tag=$( $GITHUB_WORKSPACE/build/bin/geth version|egrep "^Version" |egrep -o '[0-9].*') && \
+          echo "version_tag=$version_tag" >> $GITHUB_ENV
+      - name: Push the tag 
+        run: |
+          cd $GITHUB_WORKSPACE/kcc && git tag ${{ env.version_tag }} && git push origin ${{ env.version_tag }}
+      - name: retag the docker image 
+        run: |
+            docker tag ${{ inputs.docker_repo }}:latest ${{ inputs.docker_repo }}:${{ env.version_tag }}
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: push docker images 
+        run: |
+          docker push ${{ inputs.docker_repo }}:latest && docker push ${{ inputs.docker_repo }}:${{ env.version_tag }}
+      - uses: "marvinpinto/action-automatic-releases@latest"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          automatic_release_tag: "${{ env.version_tag }}"
+          prerelease: true
+          title: "${{ env.version_tag }}"
+          files: |
+              build/bin/geth  
+

--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -31,9 +31,13 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc_latest --sim 'kcc/(smoke|gas-block-limit|gpo)' \
              ${{ inputs.hive_extra_flags }} 
+      - name: "[hive] Pre EIP-1559: New TX Pool"
+        run: |
+            cd $GITHUB_WORKSPACE/hive && ./hive --panic --docker.output --client.checktimelimit 10m --client kcc_latest --sim 'kcc/(new-txpool)' \
+             ${{ inputs.hive_extra_flags }}  
       - name: "[hive] Pre EIP-1559"
         run: |
-            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client.checktimelimit 10m --client kcc_latest --sim 'kcc/(ancient-db|auth-server|test-flag|deploy-contract|pre-1559|new-txpool)' \
+            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client.checktimelimit 10m --client kcc_latest --sim 'kcc/(ancient-db|auth-server|test-flag|deploy-contract|pre-1559)' \
              ${{ inputs.hive_extra_flags }}  
       - name: "[hive] Synchronization  with an old client"
         run: |


### PR DESCRIPTION
## Overview 

Our previous action for creating releases is buggy.  As it is not frequent to create a release, I think it is acceptable to make it a manual job. 

## How to create a release 

Go to the "actions" tab and select the "build-and-release" action. Then, click the "Run workflow" button on the right section:   

<img width="1244" alt="image" src="https://user-images.githubusercontent.com/95088118/226571274-77fab2ea-10cd-42d0-a2f0-4b3e5ccc0ab8.png">

## How does it create a release 

- Build a docker image from the "kcc" branch  
- run the built "geth" with option "version", to get the "version info" (e.g: 1.2.0-stable or 1.2.0-unstable)  
- push the docker image  
- create new tags on the "kcc" branch with "version info"  
- create a release for the tag above  

## Required secrets 

In order to push the docker image to docker hub , you need the following secrets:    

<img width="752" alt="image" src="https://user-images.githubusercontent.com/95088118/226572233-d1182ec4-daf7-4645-832c-dbdce2a05b8e.png">


## Example 

A run of such action in my forked repo: https://github.com/junnmm/kcc/actions/runs/4477554750/jobs/7869289956 
