### PR TITLE
actions, disable simulator for inactive validators in ishikari

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -49,6 +49,6 @@ jobs:
              ${{ inputs.hive_extra_flags }}  
       - name: "[hive] Ishikari hardfork (without punishment)"
         run: |
-            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc --sim 'kcc/ishikari-(distri|inactive|multinode|singlenode)' \
+            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc --sim 'kcc/ishikari-(distri|multinode|singlenode)' \
              ${{ inputs.hive_extra_flags }}  
       


### PR DESCRIPTION
Temporally disable the simulator for inactive validators in the Ishikari hardfork.
It will start 30 containers to run this simulator, possibly leading to the OOM kill .