### PR TITLE
add litedebug mode

### DIFF
--- a/.github/workflows/hive.yml
+++ b/.github/workflows/hive.yml
@@ -51,4 +51,7 @@ jobs:
         run: |
             cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc --sim 'kcc/ishikari-(distri|multinode|singlenode)' \
              ${{ inputs.hive_extra_flags }}  
-      
+      - name: "[hive] litedebug mode"
+        run: |
+            cd $GITHUB_WORKSPACE/hive && ./hive --panic --client kcc --sim 'kcc/litedebug' \
+             ${{ inputs.hive_extra_flags }}        

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -921,5 +921,53 @@ func APIs(backend Backend) []rpc.API {
 			Namespace: "debug",
 			Service:   NewAPI(backend),
 		},
+		{
+			Namespace: "lightdebug",
+			Service:   NewLightAPI(backend),
+		},
+	}
+}
+
+// The Light API is a very simple wrapper around "API"
+// Rather than expose a lot of tracing API,
+// LightAPI only exposes the following methods:
+//
+//   - TraceTransaction
+//   - TraceBlockByNumber
+//   - TraceBlockByHash
+//   - TraceCall
+//
+// And also note that all the methods in "lightdebug" module will be exposed
+// in the "debug" module. Which means you will not call "lightdebug_traceTransaction" but
+// "debug_traceTransaction" instead.
+//
+// See node/rpcstack.go:mapNamespace
+type LightAPI struct {
+	internal *API
+}
+
+// TraceTransaction
+func (api *LightAPI) TraceTransaction(ctx context.Context, hash common.Hash, config *TraceConfig) (interface{}, error) {
+	return api.internal.TraceTransaction(ctx, hash, config)
+}
+
+// TraceBlockByNumber
+func (api *LightAPI) TraceBlockByNumber(ctx context.Context, number rpc.BlockNumber, config *TraceConfig) ([]*txTraceResult, error) {
+	return api.internal.TraceBlockByNumber(ctx, number, config)
+}
+
+// TraceBlockByHash
+func (api *LightAPI) TraceBlockByHash(ctx context.Context, hash common.Hash, config *TraceConfig) ([]*txTraceResult, error) {
+	return api.internal.TraceBlockByHash(ctx, hash, config)
+}
+
+// TraceCall
+func (api *LightAPI) TraceCall(ctx context.Context, args ethapi.TransactionArgs, blockNrOrHash rpc.BlockNumberOrHash, config *TraceCallConfig) (interface{}, error) {
+	return api.internal.TraceCall(ctx, args, blockNrOrHash, config)
+}
+
+func NewLightAPI(b Backend) *LightAPI {
+	return &LightAPI{
+		internal: NewAPI(b),
 	}
 }

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -922,7 +922,7 @@ func APIs(backend Backend) []rpc.API {
 			Service:   NewAPI(backend),
 		},
 		{
-			Namespace: "lightdebug",
+			Namespace: "litedebug",
 			Service:   NewLightAPI(backend),
 		},
 	}
@@ -937,8 +937,8 @@ func APIs(backend Backend) []rpc.API {
 //   - TraceBlockByHash
 //   - TraceCall
 //
-// And also note that all the methods in "lightdebug" module will be exposed
-// in the "debug" module. Which means you will not call "lightdebug_traceTransaction" but
+// And also note that all the methods in "litedebug" module will be exposed
+// in the "debug" module. Which means you will not call "litedebug_traceTransaction" but
 // "debug_traceTransaction" instead.
 //
 // See node/rpcstack.go:mapNamespace

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -561,10 +561,10 @@ func RegisterApis(apis []rpc.API, modules []string, srv *rpc.Server) error {
 }
 
 // module to namespace mapping
-// - methods in "lightdebug" module are exposed in "debug" namespace
+// - methods in "litedebug" module are exposed in "debug" namespace
 func mapNamespace(module string) string {
 	switch module {
-	case "lightdebug":
+	case "litedebug":
 		return "debug"
 	default:
 		return module

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -551,10 +551,22 @@ func RegisterApis(apis []rpc.API, modules []string, srv *rpc.Server) error {
 	// Register all the APIs exposed by the services
 	for _, api := range apis {
 		if allowList[api.Namespace] || len(allowList) == 0 {
-			if err := srv.RegisterName(api.Namespace, api.Service); err != nil {
+			ns := mapNamespace(api.Namespace)
+			if err := srv.RegisterName(ns, api.Service); err != nil {
 				return err
 			}
 		}
 	}
 	return nil
+}
+
+// module to namespace mapping
+// - methods in "lightdebug" module are exposed in "debug" namespace
+func mapNamespace(module string) string {
+	switch module {
+	case "lightdebug":
+		return "debug"
+	default:
+		return module
+	}
 }


### PR DESCRIPTION
Add a new `litedebug` to `--http.api` option. And expose only selected methods from the tracer API. 

TODO: 

- [x] initial implementation  
- [x] Review by @0xcary  
- [x] Add hive test cases    
   - [x]  enable "litedebug" without "debug". 
   - [x] enable both "litedebug" and "debug".  (methods from both modules are expected to be merged )